### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   cache-and-install:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/weklund/alfred-chrono-notes/security/code-scanning/5](https://github.com/weklund/alfred-chrono-notes/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- `pull-requests: write` if the workflow interacts with pull requests (e.g., updating statuses).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs. In this case, adding it at the root level is more efficient since all jobs appear to require similar permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow permissions for improved access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->